### PR TITLE
add _I means bignum and _Zq means ZqElement obj

### DIFF
--- a/include/ctbignum/decimal_literals.hpp
+++ b/include/ctbignum/decimal_literals.hpp
@@ -48,10 +48,7 @@ constexpr auto chars_to_integer_seq(std::integer_sequence<char, Chars...>,
   return std::integer_sequence<T, num[Is]...>{};
 }
 
-} //end of detail namespace
-
-namespace literals {
-template <char... Chars> constexpr auto operator"" _Z() {
+template <char... Chars> constexpr auto chars_to_index_sequence() {
 
   using T = uint64_t; // Question: How to elegantly expose the choice of this
                       // type to the user?
@@ -63,6 +60,23 @@ template <char... Chars> constexpr auto operator"" _Z() {
   constexpr auto L = detail::tight_length(num) + (to_big_int(num) == big_int<1, T>{});
   return detail::take_first(num, std::make_index_sequence<L>{});
 }
+
+} //end of detail namespace
+
+namespace literals {
+template <char... Chars> constexpr auto operator"" _Zq() {
+  return Zq(detail::chars_to_index_sequence<Chars...>());
+}
+
+template <char... Chars> constexpr auto operator"" _I() {
+  return to_big_int(detail::chars_to_index_sequence<Chars...>());
+}
+
+
+template <char... Chars> constexpr auto operator"" _Z() {
+  return detail::chars_to_index_sequence<Chars...>();
+}
+
 }
 
 } // end of cbn namespace

--- a/include/ctbignum/field.hpp
+++ b/include/ctbignum/field.hpp
@@ -15,7 +15,7 @@
 #include <ctbignum/invariant_div.hpp>
 #include <ctbignum/io.hpp>
 #include <ctbignum/mult.hpp>
-#include <ctbignum/mod_inv.hpp>
+#include <ctbignum/mod_exp.hpp>
 #include <ctbignum/slicing.hpp>
 
 #include <cstddef>


### PR DESCRIPTION
I Think big_int should be first class and I use _I represent big_int
for example:
  constexpr auto number = 6513020836420374401749667047018991798096360820_I;
  constexpr big_int<3> expected_result = {1315566964, 326042948, 19140048};

and I think ZqElement obj can be created use _Zq suffix directly:

  using GF101 = decltype(1267650600228229401496703205653_Zq);
  GF101 xb(8732191096651392800298638976_Z);
  GF101 yb(27349736_Z);

