### PR TITLE
Exposing limb type choice by introducing `_ZL` and `_ZLL`

### DIFF
--- a/include/ctbignum/decimal_literals.hpp
+++ b/include/ctbignum/decimal_literals.hpp
@@ -51,10 +51,12 @@ constexpr auto chars_to_integer_seq(std::integer_sequence<char, Chars...>,
 } //end of detail namespace
 
 namespace literals {
-template <char... Chars> constexpr auto operator"" _Z() {
+template <char... Chars> [[deprecated("Consider using _ZL or _ZLL which explicitly specifies limb size as uint32_t or uint64_t")]] constexpr auto operator"" _Z() {
 
   using T = uint64_t; // Question: How to elegantly expose the choice of this
                       // type to the user?
+                      // Answer: Check below, inspired from `The type of the literal`
+                      // table at https://en.cppreference.com/w/cpp/language/integer_literal
 
   constexpr size_t len = sizeof...(Chars);
   constexpr size_t N = 1 + (10 * len) / (3 * std::numeric_limits<T>::digits);
@@ -62,6 +64,30 @@ template <char... Chars> constexpr auto operator"" _Z() {
   auto num = detail::chars_to_integer_seq(std::integer_sequence<char, Chars...>{}, std::make_index_sequence<N>{});
   constexpr auto L = detail::tight_length(num) + (to_big_int(num) == big_int<1, T>{});
   return detail::take_first(num, std::make_index_sequence<L>{});
+}
+
+template <char... Chars> constexpr auto operator"" _ZL() {
+
+  using T = uint32_t;
+
+  constexpr size_t len = sizeof...(Chars);
+  constexpr size_t N = 1 + (10 * len) / (3 * std::numeric_limits<T>::digits);
+
+  auto num = detail::chars_to_integer_seq<T>(std::integer_sequence<char, Chars...>{}, std::make_index_sequence<N>{});
+  constexpr auto L = detail::tight_length(num) + (to_big_int(num) == big_int<1, T>{});
+  return detail::take_first<T>(num, std::make_index_sequence<L>{});
+}
+
+template <char... Chars> constexpr auto operator"" _ZLL() {
+
+  using T = uint64_t;
+
+  constexpr size_t len = sizeof...(Chars);
+  constexpr size_t N = 1 + (10 * len) / (3 * std::numeric_limits<T>::digits);
+
+  auto num = detail::chars_to_integer_seq<T>(std::integer_sequence<char, Chars...>{}, std::make_index_sequence<N>{});
+  constexpr auto L = detail::tight_length(num) + (to_big_int(num) == big_int<1, T>{});
+  return detail::take_first<T>(num, std::make_index_sequence<L>{});
 }
 }
 


### PR DESCRIPTION
Hello Niek, first of all thanks for writing `ctbignum` -- such a great and useful library. 

I'm using `ctbignum` for writing code, which I'm offloading to GPU. I noticed when converting literal input to `std::integer_sequence`, default limb type choice is `uint64_t`, which is somewhat problematic to me. As I was trying to target SPIRV, which not supporting `__uint128_t` so I was getting errors when writing GPU kernels which were performing modular multiplication. 

Also I noticed your [question](https://github.com/niekbouman/ctbignum/blob/1fd9d22eacd9af90725497c0e7405eae2ba02b86/include/ctbignum/decimal_literals.hpp#L56-L57)

I've introduced `_ZL` and `_ZLL` -- these two new literal suffixes, while deprecating `_Z`. I'd love to know your opinion/ suggestion.

Thanks :)

Suffix | Note
--- | ---
_ZL | uint32_t as limb type
_ZLL | uint64_t as limb type
_Z | uint64_t ( as it is ) as limb type [ **deprecated** ]