### PR TITLE
Fix some -Wsign-compare warnings

### DIFF
--- a/include/ctbignum/decimal_literals.hpp
+++ b/include/ctbignum/decimal_literals.hpp
@@ -54,7 +54,7 @@ namespace literals {
 template <typename T, char... Chars> constexpr auto generic_limb_literal() {
   constexpr size_t len = sizeof...(Chars);
   constexpr size_t N = 1 + (10 * len) / (3 * std::numeric_limits<T>::digits);
-  auto num = detail::chars_to_integer_seq(std::integer_sequence<char, Chars...>{}, std::make_index_sequence<N>{});
+  auto num = detail::chars_to_integer_seq<T>(std::integer_sequence<char, Chars...>{}, std::make_index_sequence<N>{});
   constexpr auto L = detail::tight_length(num) + (to_big_int(num) == big_int<1, T>{});
   return detail::take_first(num, std::make_index_sequence<L>{});
 }

--- a/include/ctbignum/io.hpp
+++ b/include/ctbignum/io.hpp
@@ -61,7 +61,7 @@ auto convert_radix(cbn::big_int<N, T> obj) {
       Radix::representation_length_upper_bound(bit_length_upper_bound);
   std::array<typename Radix::character_t, max_digits> radix_repr;
 
-  for (auto i = 0; i < max_digits; ++i) {
+  for (size_t i = 0; i < max_digits; ++i) {
     auto qr = div(obj, std::integer_sequence<T, Radix::radix>{});
     detail::assign(obj, qr.quotient);
     radix_repr[max_digits - 1 - i] = Radix::represent(qr.remainder[0]);

--- a/include/ctbignum/montgomery.hpp
+++ b/include/ctbignum/montgomery.hpp
@@ -86,7 +86,7 @@ constexpr auto montgomery_mul(big_int<N, T> x, big_int<N, T> y,
   constexpr T mprime = -inv[0];
 
   big_int<N + 1, T> A{};
-  for (auto i = 0; i < N; ++i) {
+  for (std::size_t i = 0; i < N; ++i) {
     T u_i = (A[0] + x[i] * y[0]) * mprime;
 
     // A += x[i] * y + u_i * m followed by a 1 limb-shift to the right
@@ -98,7 +98,7 @@ constexpr auto montgomery_mul(big_int<N, T> x, big_int<N, T> y,
     k = z >> std::numeric_limits<T>::digits;
     k2 = z2 >> std::numeric_limits<T>::digits;
 
-    for (auto j = 1; j < N; ++j) {
+    for (std::size_t j = 1; j < N; ++j) {
       TT t = static_cast<TT>(y[j]) * static_cast<TT>(x[i]) + A[j] + k;
       TT t2 = static_cast<TT>(m[j]) * static_cast<TT>(u_i) + static_cast<T>(t) + k2;
       A[j-1] = t2;

--- a/include/ctbignum/slicing.hpp
+++ b/include/ctbignum/slicing.hpp
@@ -99,10 +99,10 @@ template <typename T,
 constexpr auto join(big_int< N1, T> a, big_int< N2, T> b) {
   big_int< N1+N2, T> result {};
 
-  for (auto i = 0; i<N1; ++i)
+  for (size_t i = 0; i<N1; ++i)
     result[i] = a[i];
 
-  for (auto i = 0; i<N2; ++i)
+  for (size_t i = 0; i<N2; ++i)
     result[N1+i] = b[i];
   
   return result;

--- a/include/ctbignum/utility.hpp
+++ b/include/ctbignum/utility.hpp
@@ -65,7 +65,7 @@ constexpr void assign(big_int<N1, T>& dst, big_int<N2, T> src) {
   static_assert(N1 >= N2,
                 "cannot assign: destination has smaller size than source");
 
-  for (auto i = 0; i < N1; ++i)
+  for (std::size_t i = 0; i < N1; ++i)
     dst[i] = src[i];
   for (auto i = N1; i < N2; ++i)
     dst[i] = 0;


### PR DESCRIPTION
Hi, thanks for this nice library.
I used it in a project without cmake and tend to compile my code with `-Wall -Werror` and got some `-Werror=sign-compare` warnings.

`auto` defaults to `int` for a normal literal, thus the compiler complains...

The change in `decimal_literals.hpp` fixes an assignment problem if `T` is not `uint64_t`