### PR TITLE
Don't require boost when it is not used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,18 +20,6 @@ cmake_minimum_required(VERSION 3.0.0)
 project(ctbignum VERSION 0.1 LANGUAGES CXX)
 
 ##
-## INCLUDE
-##
-##
-include(ExternalProject)
-
-## External dependencies
-find_package(Boost 1.61 REQUIRED)
-if(Boost_FOUND)
-  include_directories(${Boost_INCLUDE_DIRS})
-endif()
-
-##
 ## OPTIONS
 ##
 option(default_cxx_standard "C++ standard" 20)


### PR DESCRIPTION
Boost is not used in the code, but required to build the project. Compare https://github.com/microsoft/vcpkg/issues/39850